### PR TITLE
Removes "ClassicPress Blog" H1 heading on single post pages

### DIFF
--- a/wp-content/themes/classicpress-susty-child/functions.php
+++ b/wp-content/themes/classicpress-susty-child/functions.php
@@ -4,7 +4,7 @@
  * Stylesheet version (cache buster)
  */
 function cp_susty_get_asset_version() {
-	return '20200312.2';
+	return '20200724.1';
 }
 
 
@@ -61,7 +61,7 @@ add_filter( 'admin_post_thumbnail_html', 'filter_featured_image_admin_text', 10,
 
 /****simplify blog detection*********/
 function is_blog () {
-    return ( is_archive() || is_author() || is_category() || is_home() || is_single() || is_tag()) && 'post' == get_post_type();
+    return ( is_archive() || is_author() || is_category() || is_home() || is_tag()) && 'post' == get_post_type();
 }
 
 

--- a/wp-content/themes/classicpress-susty-child/header.php
+++ b/wp-content/themes/classicpress-susty-child/header.php
@@ -105,6 +105,8 @@
 				echo '<h1>';
 				esc_html_e( 'ClassicPress Blog', 'susty' );
 				echo '</h1>';
+			} elseif (is_single()) {
+				the_title( '<h1>', '</h1>' );
 			} elseif (is_search()) {
 				echo '<h1>';
 				esc_html_e( 'Search Results', 'susty' );

--- a/wp-content/themes/classicpress-susty-child/single-acf-sidebar.php
+++ b/wp-content/themes/classicpress-susty-child/single-acf-sidebar.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Template Name: Post with Custom Sidebar
+ * Template Post Type: post
+ *
+ * A template for displaying single posts
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
+ *
+ * @package Susty
+ */
+
+get_header();
+?>
+
+	<div id="primary">
+		<main id="main">
+
+		<?php
+		while ( have_posts() ) :
+			the_post();
+
+			get_template_part( 'template-parts/content', get_post_type() );
+
+			the_post_navigation( array(
+				'next_text' => __( 'Next post: %title <span class="screen-reader-text">Continue Reading</span>' ),
+				'prev_text' => __( 'Previous post: %title <span class="screen-reader-text">Continue Reading</span>' ),
+			) );
+
+			// If comments are open or we have at least one comment, load up the comment template.
+			if ( comments_open() || get_comments_number() ) :
+				comments_template();
+			endif;
+
+		endwhile; // End of the loop.
+		?>
+
+		</main><!-- #main -->
+		<?php get_template_part( 'template-parts/sidebar', 'page' ); ?>
+	</div><!-- #primary -->
+	
+
+<?php
+get_footer();

--- a/wp-content/themes/classicpress-susty-child/template-parts/content.php
+++ b/wp-content/themes/classicpress-susty-child/template-parts/content.php
@@ -10,16 +10,20 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+<!--
 	<header class="blog">
 		<?php
+		/*
 		if ( is_singular() ) :
 			the_title( '<h1>', '</h1>' );
 		else :
 			the_title( '<h2><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 		endif;
+		*/
 		?>
-	
 	</header>
+-->
 
 	<?php susty_wp_post_thumbnail(); ?>
 

--- a/wp-content/themes/classicpress-susty-child/template-parts/content.php
+++ b/wp-content/themes/classicpress-susty-child/template-parts/content.php
@@ -10,6 +10,15 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<?php if ( ! is_singular() ) : ?>
+	<header class="blog">
+		<?php the_title(
+			'<h2><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">',
+			'</a></h2>'
+		); ?>
+	</header>
+<?php endif; ?>
+	
 	<?php susty_wp_post_thumbnail(); ?>
 
 	<div>

--- a/wp-content/themes/classicpress-susty-child/template-parts/content.php
+++ b/wp-content/themes/classicpress-susty-child/template-parts/content.php
@@ -10,21 +10,6 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-
-<!--
-	<header class="blog">
-		<?php
-		/*
-		if ( is_singular() ) :
-			the_title( '<h1>', '</h1>' );
-		else :
-			the_title( '<h2><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
-		endif;
-		*/
-		?>
-	</header>
--->
-
 	<?php susty_wp_post_thumbnail(); ?>
 
 	<div>


### PR DESCRIPTION
Single post pages previously had **two** H1 elements: a) **`ClassicPress Blog`** and b) the post title. This fix replaces **`ClassicPress Blog`** with the post title.

![blog-headings-2](https://user-images.githubusercontent.com/4199514/88382841-3ae90580-cda1-11ea-8d72-4408a51844b6.jpg)

