### PR TITLE
Removes function cp_insert_twittercard_tags() from functions.php

### DIFF
--- a/wp-content/themes/classicpress-susty-child/functions.php
+++ b/wp-content/themes/classicpress-susty-child/functions.php
@@ -4,7 +4,7 @@
  * Stylesheet version (cache buster)
  */
 function cp_susty_get_asset_version() {
-	return '20200724.1';
+	return '20200822.1';
 }
 
 


### PR DESCRIPTION
Twitter card info is currently generated using the `cp_insert_twittercard_tags()` in `functions.php`.

There are two issues with this:

1. CPSEO also generates Twitter meta.
2. The default `twitter:image` meta in `cp_insert_twittercard_tags()` is currently set to an image that does not exist. With this being hard coded, it is not so easy to change.

This PR removes the above function from `functions.php` and allows CPSEO to handle social media tags.