### PR TITLE
Removes duplicate blog category headers (SEO)

### DIFF
--- a/wp-content/themes/classicpress-susty-child/header.php
+++ b/wp-content/themes/classicpress-susty-child/header.php
@@ -100,10 +100,12 @@
 	} ?>
 
 	<?php if(!is_front_page()) {
+	    $category = get_the_category();
 			echo '<header id="page-title">';
 			if (is_blog()) {
 				echo '<h1>';
-				esc_html_e( 'ClassicPress Blog', 'susty' );
+				esc_html_e( 'ClassicPress Blog: ', 'susty' );
+				echo esc_html( ucwords( $category[0]->name ) );
 				echo '</h1>';
 			} elseif (is_single()) {
 				the_title( '<h1>', '</h1>' );

--- a/wp-content/themes/classicpress-susty-child/header.php
+++ b/wp-content/themes/classicpress-susty-child/header.php
@@ -100,7 +100,7 @@
 	} ?>
 
 	<?php if(!is_front_page()) {
-	    $category = get_the_category();
+			$category = get_the_category();
 			echo '<header id="page-title">';
 			if (is_blog()) {
 				echo '<h1>';


### PR DESCRIPTION
All blog category pages currently have the exact same `h1` title of `ClassicPress Blog`.

For examples, see:

https://www.classicpress.net/blog/category/classicpress-values/
https://www.classicpress.net/blog/category/featured-post/

At the top of the page, you will just see `ClassicPress Blog` for each page.

This is not good for SEO and is meaningless to the visitor.

This PR simply appends the category name to the title. For example:

`ClassicPress Blog: ClassicPress Values`
`ClassicPress Blog: Featured Post`

The reason for the use of `ucwords` is in case any categories are written in lowercase.