### PR TITLE
Remove duplicate featured image in pages

### DIFF
--- a/wp-content/themes/classicpress-susty-child/template-parts/content-page.php
+++ b/wp-content/themes/classicpress-susty-child/template-parts/content-page.php
@@ -14,8 +14,6 @@
 		<?php //the_title( '<h1>', '</h1>' ); ?>
 	</header--><!-- .entry-header -->
 
-	<?php susty_wp_post_thumbnail(); ?>
-
 	<div id="page-content">
 		<?php
 		the_content();


### PR DESCRIPTION
When a featured image is added to a page, it displays twice. This is because the function `susty_wp_post_thumbnail();` appears in both `page.php` and `template-parts/content-page.php`. This fix removes the function from the latter.

**Example:**

![duplicate-featured-images](https://user-images.githubusercontent.com/4199514/92312028-ec8c7080-efb4-11ea-9228-d69268e7cf41.jpg)
