### PR TITLE
Update blog category pages to show only excerpt

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -152,6 +152,7 @@ RedirectMatch 301 ^/our-mission/?$ /about/
 RedirectMatch 301 ^/translating-classicpress/?$ /blog/classicpress-localization/
 RedirectMatch 301 ^/increase-your-plugin-audience-with-classicpress-users/?$ /for-plugin-developers/
 RedirectMatch 301 ^/join-discord/?$ /community/
+RedirectMatch 301 ^/blog/category/classicpress-blog/? /blog/
 # END 301 Redirects
 
 # BEGIN 302 Redirects

--- a/wp-content/themes/classicpress-susty-child/archive.php
+++ b/wp-content/themes/classicpress-susty-child/archive.php
@@ -25,7 +25,7 @@ get_header();
 
 				endwhile; ?>
 
-			</div> <?php
+			</div><!-- .blog-list --> <?php
 
 			the_posts_navigation();
 
@@ -36,9 +36,9 @@ get_header();
 		endif;
 		?>
 
-		</main>
+		</main><!-- #main -->
 		<?php get_template_part( 'template-parts/sidebar', 'blog' ); ?>
-	</div>
+	</div><!-- #primary -->
 
 <?php
 get_footer();

--- a/wp-content/themes/classicpress-susty-child/archive.php
+++ b/wp-content/themes/classicpress-susty-child/archive.php
@@ -9,45 +9,36 @@
 
 get_header();
 ?>
-
 	<div id="primary">
 		<main id="main">
 
-		<?php if ( have_posts() ) : ?>
+		<?php
+		if ( have_posts() ) : ?>
 
-			<header>
-				<?php
-				the_archive_title( '<h3>', '</h3>' );
-				the_archive_description( '<div class="archive-desc">', '</div>' );
-				?>
-			</header>
+			<div class="blog-list"> <?php
 
-			<?php
-			/* Start the Loop */
-			while ( have_posts() ) :
-				the_post();
+				/* Start the Loop */
+				while ( have_posts() ) :
+					the_post();
 
-				/*
-				 * Include the Post-Type-specific template for the content.
-				 * If you want to override this in a child theme, then include a file
-				 * called content-___.php (where ___ is the Post Type name) and that will be used instead.
-				 */
-				get_template_part( 'template-parts/content', get_post_type() );
+					get_template_part( 'template-parts/content-blog', get_post_type() );
 
-			endwhile;
+				endwhile; ?>
+
+			</div> <?php
 
 			the_posts_navigation();
 
-		else :
+		else:
 
 			get_template_part( 'template-parts/content', 'none' );
 
 		endif;
 		?>
 
-		</main><!-- #main -->
+		</main>
 		<?php get_template_part( 'template-parts/sidebar', 'blog' ); ?>
-	</div><!-- #primary -->
+	</div>
 
 <?php
 get_footer();


### PR DESCRIPTION
This updates the theme `archive.php` file to give the blog category pages the same layout as the home blog page https://www.classicpress.net/blog/. 

At present, each blog category page displays all posts in full. This updated version only shows the excerpt.

It is also intended to remove the `classicpress-blog` category from the website as this seems to be quite a pointless category. Posts from that category will be moved into more appropriate categories.

Removing this category also requires a change to `.htaccess` so that https://www.classicpress.net/blog/category/classicpress-blog/ is redirected to https://www.classicpress.net/blog/, the blog home page.
