### PR TITLE
Displays blog category archive page heading based on page slug

### DIFF
--- a/wp-content/themes/classicpress-susty-child/functions.php
+++ b/wp-content/themes/classicpress-susty-child/functions.php
@@ -4,7 +4,7 @@
  * Stylesheet version (cache buster)
  */
 function cp_susty_get_asset_version() {
-	return '20200911.3';
+	return '20200917.1';
 }
 
 

--- a/wp-content/themes/classicpress-susty-child/header.php
+++ b/wp-content/themes/classicpress-susty-child/header.php
@@ -100,12 +100,15 @@
 	} ?>
 
 	<?php if(!is_front_page()) {
-			$category = get_the_category();
+			$category = single_cat_title("", false);
 			echo '<header id="page-title">';
 			if (is_blog()) {
 				echo '<h1>';
-				esc_html_e( 'ClassicPress Blog: ', 'susty' );
-				echo esc_html( ucwords( $category[0]->name ) );
+				esc_html_e( 'ClassicPress Blog', 'susty' );
+				if ( $category != '' ) {
+					esc_html_e( ': ', 'susty' );
+					echo esc_html( ucwords( $category ) );
+				}
 				echo '</h1>';
 			} elseif (is_single()) {
 				the_title( '<h1>', '</h1>' );

--- a/wp-content/themes/classicpress-susty-child/style.css
+++ b/wp-content/themes/classicpress-susty-child/style.css
@@ -380,6 +380,10 @@ button {
 	font-weight: 600;
 }
 
+#content .widget-container ul li.cat-item.current-cat a {
+	color:#040402;
+}
+
 /* External link icon */
 article a[target='_blank']::after {
 	font-size: 60%;


### PR DESCRIPTION
At present, the page heading on each blog category archive page is showing the name of the category of the first item on the page instead of the name of the category itself, which can be quite confusing.

In the screenshot below, we're on the `Updates` category page but the page heading is showing `Core Development` as this is the first category of the first post (_Introducing ClassicPress 1.1.0_) on the page.


![blog-category-page-before](https://user-images.githubusercontent.com/4199514/93506116-aec40c00-f913-11ea-90ef-854dfc6e45a2.jpg)


To get around this, in the theme's `header.php`, the `$category` variable has been set to `single_cat_title("", false)` instead of `get_the_category()` as it was previously. 

Here's the same page after the fix:


![blog-category-page-after](https://user-images.githubusercontent.com/4199514/93506701-88eb3700-f914-11ea-9d3e-475c98ffebbf.jpg)


A rule has also been added to `style.css` to change the color of the active item in the sidebar menu.

The cache buster has been updated in `functions.php`.