### PR TITLE
Ignore auto-generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.env
 /vendor/
 /wp-content/uploads/
+/wp-content/autoptimize_404_handler.php


### PR DESCRIPTION
Ignore an auto-generated file created by the Autoptimize plugin. The contents of this file differ based on the install location (for local development this changes), so it should be ignored in the repository and re-created by the plugin as needed.