### PR TITLE
Fix for parse error in cp-donations.php (v2.0.1)

### DIFF
--- a/wp-content/plugins/cp-donations/CHANGES.md
+++ b/wp-content/plugins/cp-donations/CHANGES.md
@@ -1,3 +1,6 @@
+#### v 2.0.1 / 2021-02-26
+* fix for PHP Parse error:  syntax error, unexpected ')' in cp-donations.php on line 106
+
 #### v 2.0.0 / 2021-02-17
 * Addition of custom amount feature to allow donations of any amount.
 * Shortcode now accepts product ID as parameter.

--- a/wp-content/plugins/cp-donations/cp-donations.php
+++ b/wp-content/plugins/cp-donations/cp-donations.php
@@ -3,7 +3,7 @@
  * Plugin Name: Donations for ClassicPress
  * Plugin URI: https://github.com/timbocode/cc-donations
  * Description: Frontend interface for donations and subscriptions
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: timbocode
  * Author URI: https://github.com/timbocode
  * Text Domain: cp_donations_domain
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class CP_Donations {
 
-	public $version = '2.0.0';
+	public $version = '2.0.1';
 	public $db_version = '1';
 	private $min_cp_version = '1.0.2';
 	private $php_version = '7.0';
@@ -101,8 +101,8 @@ class CP_Donations {
 		if ( version_compare( get_bloginfo( 'version' ), $this->min_cp_version, '<' ) ) {
 			$notice = sprintf(
 				// Translators: %s ClassicPress version number.
-				__( '<strong>CP Donations requires ClassicPress version %s or above. Please update ClassicPress.', 'cp_donations_domain' ),
-				$this->min_cp_version,
+				__( 'CP Donations requires ClassicPress version %s or above. Please update ClassicPress.', 'cp_donations_domain' ),
+				$this->min_cp_version
 			);
 			CPD_Admin_Notices::add_notice( $notice, 'error' );
 			return false;


### PR DESCRIPTION
Fixes `PHP Parse error:  syntax error, unexpected ')' in cp-donations.php on line 106` 

v2.0.1