### PR TITLE
Fix tagline alignment on the homepage

### DIFF
--- a/wp-content/themes/classicpress-susty-child/style.css
+++ b/wp-content/themes/classicpress-susty-child/style.css
@@ -1749,7 +1749,7 @@ footer#legal {
 
 .home-hero-text h3 {
 	margin-top: 0;
-	font-size: 1.7em;
+	font-size: 1.5em;
 }
 
 .home-hero-image {


### PR DESCRIPTION
Reducing font size of the new tagline on the homepage to fix alignment issue due to the text being too wide when "Lightweight" replaced "Secure".

**Result:**
![image](https://user-images.githubusercontent.com/1692600/132444437-16947e54-7bdc-42e0-8851-b920f003aa8a.png)


